### PR TITLE
Display file names without paths

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -38,7 +38,11 @@ const editorExtension = ViewPlugin.fromClass(
 							}
 
 							const link = view.state.sliceDoc(node.from, node.to);
-							const lastIndex = link.lastIndexOf("#");
+							var lastIndex = link.lastIndexOf("#");
+							console.log(lastIndex);
+							if (lastIndex < 0) {
+								lastIndex = link.lastIndexOf("/");
+							}
 							if (lastIndex < 0) {
 								return;
 							}

--- a/main.ts
+++ b/main.ts
@@ -39,7 +39,6 @@ const editorExtension = ViewPlugin.fromClass(
 
 							const link = view.state.sliceDoc(node.from, node.to);
 							var lastIndex = link.lastIndexOf("#");
-							console.log(lastIndex);
 							if (lastIndex < 0) {
 								lastIndex = link.lastIndexOf("/");
 							}


### PR DESCRIPTION
Hi, I made a small tweak that also removes the path from the displayed link, showing only the file name instead. 
If a heading is linked to only that is shown but if no heading is linked, then only the file name is shown.

I found this to be useful since some of my files are quite deeply nested and links got very long but it's up to you if you want to include it. 