### PR TITLE
Typo in description for setting

### DIFF
--- a/sources/configuration.ts
+++ b/sources/configuration.ts
@@ -68,7 +68,7 @@ export class ShortLinkPluginSettingTab extends PluginSettingTab {
 
 		new Setting(this.containerEl)
 			.setName("Short links to files")
-			.setDesc("Only show the file name in links to headings.")
+			.setDesc("Only show the file name in links to files.")
 			.addToggle((toggle) =>
 				toggle.setValue(configuration.shortLinksToFiles).onChange((newValue) => {
 					configuration.shortLinksToFiles = newValue;


### PR DESCRIPTION
Only show the filename in links to files. I assume this is to hide the folder path. And I assume that it was just a mistake with copy and pasting from the other settings?